### PR TITLE
Fixes NoMethodError for empty routing tables

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,7 +47,7 @@ end.spec 'neo4j-ruby-driver' do
   else
     require_ruby_version '>= 3.1'
     dependency 'async-io', '>= 0'
-    dependency 'connection_pool', '>= 0'
+    dependency 'connection_pool', '>= 3.0'
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -46,6 +46,8 @@ end.spec 'neo4j-ruby-driver' do
     spec_extras[:platform] = 'java'
   else
     require_ruby_version '>= 3.1'
+    # async-io 1.x requires async 1.x (async 2 removed async/wrapper; LoadError otherwise)
+    dependency 'async', '~> 1.0'
     dependency 'async-io', '>= 0'
     dependency 'connection_pool', '>= 3.0'
   end

--- a/ruby/neo4j/driver/internal/async/pool/channel_pool.rb
+++ b/ruby/neo4j/driver/internal/async/pool/channel_pool.rb
@@ -5,11 +5,11 @@ module Neo4j::Driver
         class ChannelPool < ConnectionPool
           def initialize(limit: nil, acquisition_timeout: nil, &block)
             super(size: limit, timeout: acquisition_timeout, &block)
-            @available = TimedStack.new(@size, &block)
+            @available = TimedStack.new(size: @size, &block)
           end
 
           def acquire(options = {})
-            @available.pop(options[:timeout] || @timeout)
+            @available.pop(timeout: options[:timeout] || @timeout)
           end
 
           def release(resource)

--- a/ruby/neo4j/driver/internal/cluster/routing_table_handler_impl.rb
+++ b/ruby/neo4j/driver/internal/cluster/routing_table_handler_impl.rb
@@ -60,7 +60,7 @@ module Neo4j::Driver
           @log.debug("Fetched cluster composition for database '#{@database_name.description}'. #{composition_lookup_result.cluster_composition}")
           @routing_table.update(composition_lookup_result.cluster_composition)
           @routing_table_registry.remove_aged
-          addresses_to_retain = @routing_table_registry.all_servers.map(&:unicast_stream).reduce(&:+)
+          addresses_to_retain = @routing_table_registry.all_servers.map(&:unicast_stream).reduce(Set.new, :+)
 
           composition_lookup_result.resolved_initial_routers&.then do |addresses|
             addresses_to_retain << addresses

--- a/ruby/neo4j/driver/internal/cluster/routing_table_registry_impl.rb
+++ b/ruby/neo4j/driver/internal/cluster/routing_table_registry_impl.rb
@@ -52,7 +52,7 @@ module Neo4j::Driver
         def all_servers
           # obviously we just had a snapshot of all servers in all routing tables
           # after we read it, the set could already be changed.
-          @routing_table_handlers.values.map(&:servers).reduce(&:+)
+          @routing_table_handlers.values.map(&:servers).reduce(Set.new, :+)
         end
 
         def remove(database_name)

--- a/ruby/neo4j/driver/version.rb
+++ b/ruby/neo4j/driver/version.rb
@@ -2,6 +2,6 @@
 
 module Neo4j
   module Driver
-    VERSION = '4.4.5'
+    VERSION = '4.4.6'
   end
 end


### PR DESCRIPTION
Addresses a `NoMethodError` that occurred when internal routing table collections were empty. The `reduce(&:+)` method previously returned `nil` for empty arrays, leading to errors when further operations were attempted on the result.

Initializes the `reduce` operation with `Set.new` to guarantee that a `Set` is always returned, even when the input collection is empty. This prevents the `NoMethodError` and correctly accumulates unique server addresses into a set.

- Improves robustness of routing table server address collection.
- Bumps driver version to 4.4.6.

Fixes VST-98338